### PR TITLE
fix: Исправление генерируемого `ID` для `Headless UI`

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { provideUseId } from "@headlessui/vue"
+
+provideUseId(() => useId())
+
 const i18nHead = useLocaleHead({
   addDirAttribute: true,
   addSeoAttributes: true,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -75,4 +75,9 @@ export default defineNuxtConfig({
   tailwindcss: {
     viewer: false,
   },
+  vite: {
+    optimizeDeps: {
+      exclude: ["@headlessui/vue"],
+    },
+  },
 })


### PR DESCRIPTION
- Использование `useId` для `Headless UI`
- Добавление `Headless UI` в исключения оптимизации Vite