### PR TITLE
fix: Закрытие мобильного меню при навигации

### DIFF
--- a/components/the-header/navigation/mobile/TheHeaderNavigationMobileCard.vue
+++ b/components/the-header/navigation/mobile/TheHeaderNavigationMobileCard.vue
@@ -7,8 +7,6 @@ const props = defineProps<{
 const { t } = useI18n()
 const localeRoute = useLocaleRoute()
 
-const NuxtLink = resolveComponent("NuxtLink")
-
 /** Полученный объект `route` для навигации */
 const navigationRoute = localeRoute({
   name: toRefs(props).routeName.value,
@@ -17,10 +15,9 @@ const navigationRoute = localeRoute({
 
 <template>
   <HeadlessMenuItem
-    :as="NuxtLink"
-    class="w-full rounded px-3 py-2 hover:bg-neutral-50 dark:hover:bg-neutral-800"
-    exact-active-class="hover:bg-white dark:hover:bg-neutral-900 cursor-default"
-    :to="navigationRoute"
+    as="span"
+    class="w-full cursor-pointer rounded px-3 py-2 hover:bg-neutral-50 dark:hover:bg-neutral-800"
+    @click="navigateTo(navigationRoute)"
   >
     {{ t(`pages.${routeName}`) }}
   </HeadlessMenuItem>

--- a/tests/components/the-header/navigation/mobile/TheHeaderNavigationMobile.spec.ts
+++ b/tests/components/the-header/navigation/mobile/TheHeaderNavigationMobile.spec.ts
@@ -24,7 +24,7 @@ describe("Компонент TheHeaderNavigationMobile", () => {
   })
 
   const navigationMenu = () => wrapper.findComponent({ name: "MenuItems" })
-  const menuButton = () => wrapper.findComponent({ name: "menuButton" })
+  const menuButton = () => wrapper.findComponent({ name: "MenuButton" })
 
   describe("Открытие мобильного меню", () => {
     test("Мобильное меню по умолчанию закрыто", () => {
@@ -52,6 +52,18 @@ describe("Компонент TheHeaderNavigationMobile", () => {
       const navigationLinksCount = navigationMenu().element.childElementCount
 
       expect(navigationLinksCount).toBe(navigation.length)
+    })
+
+    test("Меню закрывается при нажатии на ссылку", async () => {
+      await menuButton().trigger("click")
+
+      const navigationLinks = navigationMenu().findAllComponents({
+        name: "MenuItem",
+      })
+
+      await navigationLinks[1].trigger("click")
+
+      expect(navigationMenu().isVisible()).toBeFalsy()
     })
   })
 })


### PR DESCRIPTION
- Использование `span` вместо `NuxtLink` для правильной обработки нажатия
- Тестирование

### Связанная задача
Fixes EXR7-114