### PR TITLE
feat: Блок «Проекты»

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -27,7 +27,7 @@
   }
 
   small {
-    @apply text-sm text-neutral-400 md:text-lg dark:text-neutral-500;
+    @apply text-sm text-neutral-400 md:text-base dark:text-neutral-500;
   }
 }
 

--- a/components/personal-projects/PersonalProjectsCard.vue
+++ b/components/personal-projects/PersonalProjectsCard.vue
@@ -37,15 +37,11 @@ defineProps<{
         />
       </LazyNuxtLink>
     </div>
-    <!-- Заголовок и описание -->
-    <h4>{{ personalProject.title }}</h4>
-    <p>{{ personalProject.description }}</p>
-    <!-- Список тегов -->
-    <LazyUiTags
-      v-if="personalProject.tags.length"
-      data-test-id="tags"
-      small
+    <!-- Контент карточки -->
+    <UiCardContent
+      :description="personalProject.description"
       :tags="personalProject.tags"
+      :title="personalProject.title"
     />
   </div>
 </template>

--- a/components/projects/Projects.vue
+++ b/components/projects/Projects.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+const props = defineProps<{
+  /** Скрыть ли заголовок блока */
+  hideTitle?: boolean
+  /** Ограничение количества проектов для вывода */
+  limit?: number
+}>()
+
+const { locale, t } = useI18n({
+  useScope: "local",
+})
+
+const { data: projects } = await useFetch("/api/projects", {
+  headers: {
+    "Accept-Language": locale,
+  },
+  query: {
+    limit: toRefs(props).limit,
+  },
+})
+</script>
+
+<template>
+  <UiBlock id="projects" :title="hideTitle ? undefined : t('projects')">
+    <div
+      class="grid grid-cols-1 grid-rows-[repeat(5,_auto)] gap-4 sm:grid-cols-2 lg:grid-cols-4"
+    >
+      <ProjectsCard v-for="project in projects" :key="project.id" :project />
+      <div v-if="limit" class="row-span-4 flex items-center justify-center">
+        <LazyNuxtLinkLocale class="button secondary" to="/projects#projects">
+          {{ t("viewAll") }}
+        </LazyNuxtLinkLocale>
+      </div>
+    </div>
+  </UiBlock>
+</template>
+
+<i18n lang="json">
+{
+  "en": {
+    "projects": "Projects",
+    "viewAll": "View all"
+  },
+  "ru": {
+    "projects": "Проекты",
+    "viewAll": "Смотреть все"
+  }
+}
+</i18n>

--- a/components/projects/ProjectsCard.vue
+++ b/components/projects/ProjectsCard.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import type { Project } from "~/server/database/schema/project"
+import type { Tag } from "~/server/database/schema/tag"
+
+defineProps<{
+  /** Проект */
+  project: {
+    description: string
+    tags: Tag[]
+    title: string
+  } & Omit<
+    Project,
+    "createdAt" | "descriptionEN" | "descriptionRU" | "titleEN" | "titleRU"
+  >
+}>()
+
+const { t } = useI18n({
+  useScope: "local",
+})
+</script>
+
+<template>
+  <div class="card row-span-5 grid grid-rows-subgrid gap-y-5 overflow-hidden">
+    <!-- Логотип проекта -->
+    <div
+      class="flex aspect-video size-full items-center justify-center rounded-2xl border-b px-6 py-8"
+      :style="{ backgroundColor: project.backgroundColor }"
+    >
+      <NuxtImg
+        class="size-full"
+        format="svg"
+        provider="cloudinary"
+        :src="project.logo"
+      />
+    </div>
+    <!-- Контент карточки -->
+    <div class="row-span-4 -mt-5 grid grid-rows-subgrid p-6">
+      <UiCardContent
+        :description="project.description"
+        :tags="project.tags"
+        :title="project.title"
+      />
+      <div class="flex items-end justify-between">
+        <!-- Год проекта -->
+        <small>{{ project.year }}</small>
+        <!-- Ссылка на проект -->
+        <NuxtLink
+          class="text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-500 dark:hover:text-blue-400"
+          external
+          target="_blank"
+          :to="project.url"
+        >
+          {{ t("view") }}
+        </NuxtLink>
+      </div>
+    </div>
+  </div>
+</template>
+
+<i18n lang="json">
+{
+  "ru": {
+    "view": "Перейти"
+  },
+  "en": {
+    "view": "View"
+  }
+}
+</i18n>

--- a/components/projects/ProjectsCard.vue
+++ b/components/projects/ProjectsCard.vue
@@ -24,6 +24,7 @@ const { t } = useI18n({
     <!-- Логотип проекта -->
     <div
       class="flex aspect-video size-full items-center justify-center rounded-2xl border-b px-6 py-8"
+      data-test-id="logo"
       :style="{ backgroundColor: project.backgroundColor }"
     >
       <NuxtImg
@@ -46,6 +47,7 @@ const { t } = useI18n({
         <!-- Ссылка на проект -->
         <NuxtLink
           class="text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-500 dark:hover:text-blue-400"
+          data-test-id="project-link"
           external
           target="_blank"
           :to="project.url"

--- a/components/ui/UiBlock.vue
+++ b/components/ui/UiBlock.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 defineProps<{
   /** Заголовок блока */
-  title: string
+  title?: string
 }>()
 </script>
 
 <template>
   <div class="flex flex-col gap-y-[3.25rem]">
-    <h2>{{ title }}</h2>
+    <h2 v-if="title">{{ title }}</h2>
     <slot />
   </div>
 </template>

--- a/components/ui/UiCardContent.vue
+++ b/components/ui/UiCardContent.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import type { Tag } from "~/server/database/schema/tag"
+
+defineProps<{
+  /** Описание карточки */
+  description: string
+  /** Теги карточки */
+  tags: Tag[]
+  /** Заголовок карточки */
+  title: string
+}>()
+</script>
+
+<template>
+  <!-- Заголовок и описание -->
+  <h4>{{ title }}</h4>
+  <p class="-mt-2">{{ description }}</p>
+  <!-- Список тегов -->
+  <LazyUiTags v-if="tags.length" data-test-id="tags" small :tags />
+</template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -80,6 +80,11 @@ export default defineNuxtConfig({
     ],
     trailingSlash: true,
   },
+  image: {
+    cloudinary: {
+      baseURL: "https://res.cloudinary.com/exer7um/image/upload/",
+    },
+  },
   postcss: {
     plugins: {
       "tailwindcss/nesting": "postcss-nesting",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,6 +9,7 @@ useSeoMeta({
 
 <template>
   <main>
+    <Projects :limit="3" />
     <PersonalProjects :limit="3" />
   </main>
 </template>

--- a/pages/projects.vue
+++ b/pages/projects.vue
@@ -10,6 +10,7 @@ useSeoMeta({
 <template>
   <main>
     <h1>{{ t("pages.projects") }}</h1>
+    <Projects hide-title />
     <PersonalProjects />
   </main>
 </template>

--- a/tests/components/personal-projects/PersonalProjects.spec.ts
+++ b/tests/components/personal-projects/PersonalProjects.spec.ts
@@ -73,6 +73,14 @@ describe("Компонент PersonalProjects", () => {
 
       expect(viewAllButton().exists()).toBeTruthy()
     })
+
+    test.fails("Переводит на правильную страницу", async () => {
+      await wrapper.setProps({
+        limit: 3,
+      })
+
+      expect(viewAllButton().attributes()).toBe("/projects#personal-projects")
+    })
   })
 
   describe.sequential("Запрос к API", () => {

--- a/tests/components/personal-projects/PersonalProjectsCard.spec.ts
+++ b/tests/components/personal-projects/PersonalProjectsCard.spec.ts
@@ -15,6 +15,8 @@ describe("Компонент PersonalProjectsCard", () => {
 
   const cardContentAttributes = () =>
     wrapper.findComponent(UiCardContent).attributes()
+  const githubLinkAttributes = () =>
+    wrapper.find("[data-test-id=github-link]").attributes()
 
   beforeEach(async () => {
     wrapper = await mountSuspended(PersonalProjectsCard, {
@@ -46,20 +48,18 @@ describe("Компонент PersonalProjectsCard", () => {
       )
     })
 
-    test("Ссылка на GitHub", () => {
-      expect(wrapper.find("[data-test-id=github-link]").attributes().to).toBe(
-        personalProject.github
-      )
-    })
-
     test("Теги", () => {
       expect(cardContentAttributes().tags).toBe(personalProject.tags.toString())
     })
   })
 
-  test("Ссылка на GitHub открывается в новой вкладке", () => {
-    expect(wrapper.find("[data-test-id=github-link]").attributes().target).toBe(
-      "_blank"
-    )
+  describe("Ссылка на GitHub", () => {
+    test("Выставляется из props", () => {
+      expect(githubLinkAttributes().to).toBe(personalProject.github)
+    })
+
+    test("Открывается в новой вкладке", () => {
+      expect(githubLinkAttributes().target).toBe("_blank")
+    })
   })
 })

--- a/tests/components/personal-projects/PersonalProjectsCard.spec.ts
+++ b/tests/components/personal-projects/PersonalProjectsCard.spec.ts
@@ -4,6 +4,7 @@ import { mountSuspended } from "@nuxt/test-utils/runtime"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
 
 import PersonalProjectsCard from "~/components/personal-projects/PersonalProjectsCard.vue"
+import UiCardContent from "~/components/ui/UiCardContent.vue"
 
 import { personalProjects } from "./PersonalProjects.spec"
 
@@ -11,6 +12,9 @@ describe("Компонент PersonalProjectsCard", () => {
   const personalProject = personalProjects[0]
 
   let wrapper: VueWrapper
+
+  const cardContentAttributes = () =>
+    wrapper.findComponent(UiCardContent).attributes()
 
   beforeEach(async () => {
     wrapper = await mountSuspended(PersonalProjectsCard, {
@@ -27,11 +31,13 @@ describe("Компонент PersonalProjectsCard", () => {
 
   describe("Правильная передача полей", () => {
     test("Заголовок", () => {
-      expect(wrapper.find("h4").text()).toBe(personalProject.title)
+      expect(cardContentAttributes().title).toBe(personalProject.title)
     })
 
     test("Описание", () => {
-      expect(wrapper.find("p").text()).toBe(personalProject.description)
+      expect(cardContentAttributes().description).toBe(
+        personalProject.description
+      )
     })
 
     test("Иконка", () => {
@@ -47,20 +53,8 @@ describe("Компонент PersonalProjectsCard", () => {
     })
 
     test("Теги", () => {
-      expect(wrapper.find("[data-test-id=tags]").attributes().tags).toBe(
-        personalProject.tags.toString()
-      )
+      expect(cardContentAttributes().tags).toBe(personalProject.tags.toString())
     })
-  })
-
-  test("Список тегов отсутствует при пустом массиве", async () => {
-    personalProject.tags = []
-
-    await wrapper.setProps({
-      personalProject,
-    })
-
-    expect(wrapper.find("[data-test-id=tags]").exists()).toBeFalsy()
   })
 
   test("Ссылка на GitHub открывается в новой вкладке", () => {

--- a/tests/components/projects/Projects.spec.ts
+++ b/tests/components/projects/Projects.spec.ts
@@ -1,0 +1,115 @@
+import type { VueWrapper } from "@vue/test-utils"
+import type { H3Event } from "h3"
+
+import { getHeaderLocale } from "@intlify/h3"
+import { mountSuspended, registerEndpoint } from "@nuxt/test-utils/runtime"
+import { getQuery } from "h3"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import Projects from "~/components/projects/Projects.vue"
+import ProjectsCard from "~/components/projects/ProjectsCard.vue"
+
+import { tags } from "../ui/tags/UiTags.spec"
+
+export const projects = [
+  {
+    backgroundColor: "#000000",
+    description: "Интернет-магазин брендовой одежды",
+    id: 1,
+    logo: "/oonyxx-store.svg",
+    tags,
+    title: "oonyxx.store",
+    url: "https://exer7um.github.io/Oonyxx-Store/",
+    year: 2019,
+  },
+  {
+    backgroundColor: "#000000",
+    description: "Интернет-магазин брендовой одежды",
+    id: 2,
+    logo: "/oonyxx-store.svg",
+    tags,
+    title: "oonyxx.store",
+    url: "https://exer7um.github.io/Oonyxx-Store/",
+    year: 2019,
+  },
+]
+
+describe("Компонент Projects", () => {
+  let wrapper: VueWrapper
+  let userRequest: H3Event | undefined
+
+  const viewAllButton = () => wrapper.findComponent({ name: "NuxtLinkLocale" })
+
+  registerEndpoint("/api/projects", (request) => {
+    userRequest = request
+
+    return projects
+  })
+
+  beforeEach(async () => {
+    wrapper = await mountSuspended(Projects)
+  })
+
+  afterEach(() => {
+    userRequest = undefined
+    wrapper.unmount()
+  })
+
+  describe("Заголовок блока", () => {
+    test("По умолчанию отображается", () => {
+      expect(wrapper.find("h2").text()).toBe("Проекты")
+    })
+
+    test("Скрывается при передаче параметра", async () => {
+      await wrapper.setProps({
+        hideTitle: true,
+      })
+
+      expect(wrapper.find("h2").exists()).toBeFalsy()
+    })
+  })
+
+  test("Количество проектов", () => {
+    expect(wrapper.findAllComponents(ProjectsCard).length).toBe(projects.length)
+  })
+
+  describe("Кнопка «Показать все»", () => {
+    test("По умолчанию кнопка не отображается", () => {
+      expect(viewAllButton().exists()).toBeFalsy()
+    })
+
+    test.fails("Отображается при переданном limit", async () => {
+      await wrapper.setProps({
+        limit: 3,
+      })
+
+      expect(viewAllButton().exists()).toBeTruthy()
+    })
+
+    test.fails("Переводит на правильную страницу", async () => {
+      await wrapper.setProps({
+        limit: 3,
+      })
+
+      expect(viewAllButton().attributes()).toBe("/projects#projects")
+    })
+  })
+
+  describe.sequential("Запрос к API", () => {
+    test("Передается хедер локализации", () => {
+      expect(getHeaderLocale(userRequest!).baseName).toBeTruthy()
+    })
+
+    test("По умолчанию limit не передается", () => {
+      expect(getQuery(userRequest!).limit).toBeFalsy()
+    })
+
+    test("Передается limit", async () => {
+      await wrapper.setProps({
+        limit: 3,
+      })
+
+      expect(getQuery(userRequest!).limit).toBe("3")
+    })
+  })
+})

--- a/tests/components/projects/ProjectsCard.spec.ts
+++ b/tests/components/projects/ProjectsCard.spec.ts
@@ -1,0 +1,84 @@
+import type { VueWrapper } from "@vue/test-utils"
+
+import { mountSuspended } from "@nuxt/test-utils/runtime"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import ProjectsCard from "~/components/projects/ProjectsCard.vue"
+import UiCardContent from "~/components/ui/UiCardContent.vue"
+
+import { projects } from "./Projects.spec"
+
+describe("Компонент ProjectsCard", () => {
+  const project = projects[0]
+
+  let wrapper: VueWrapper
+
+  const cardContentAttributes = () =>
+    wrapper.findComponent(UiCardContent).attributes()
+  const logoAttributes = () =>
+    wrapper.findComponent({ name: "NuxtImg" }).attributes()
+  const projectLinkAttributes = () =>
+    wrapper.find("[data-test-id=project-link]").attributes()
+
+  beforeEach(async () => {
+    wrapper = await mountSuspended(ProjectsCard, {
+      props: {
+        project,
+      },
+      shallow: true,
+    })
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
+  describe("Правильная передача полей", () => {
+    test("Заголовок", () => {
+      expect(cardContentAttributes().title).toBe(project.title)
+    })
+
+    test("Описание", () => {
+      expect(cardContentAttributes().description).toBe(project.description)
+    })
+
+    test("Теги", () => {
+      expect(cardContentAttributes().tags).toBe(project.tags.toString())
+    })
+
+    test("Год", () => {
+      expect(wrapper.find("small").text()).toBe(project.year.toString())
+    })
+  })
+
+  describe("Логотип проекта", () => {
+    test("Выставляется фон из props", () => {
+      expect(
+        wrapper.find<HTMLDivElement>("[data-test-id=logo]").element.style
+          .backgroundColor
+      ).toBe(project.backgroundColor)
+    })
+
+    test("Формат SVG", () => {
+      expect(logoAttributes().format).toBe("svg")
+    })
+
+    test("Провайдер Cloudinary", () => {
+      expect(logoAttributes().provider).toBe("cloudinary")
+    })
+
+    test("Значение из props", () => {
+      expect(logoAttributes().src).toBe(project.logo)
+    })
+  })
+
+  describe("Ссылка на проект", () => {
+    test("Правильно передается из props", () => {
+      expect(projectLinkAttributes().to).toBe(project.url)
+    })
+
+    test("Открывается в новой вкладке", () => {
+      expect(projectLinkAttributes().target).toBe("_blank")
+    })
+  })
+})

--- a/tests/components/ui/UiBlock.spec.ts
+++ b/tests/components/ui/UiBlock.spec.ts
@@ -13,9 +13,6 @@ describe("Компонент UiBlock", () => {
 
   beforeEach(async () => {
     wrapper = await mountSuspended(UiBlock, {
-      props: {
-        title,
-      },
       slots: {
         default: () => testBlock,
       },
@@ -26,8 +23,16 @@ describe("Компонент UiBlock", () => {
     wrapper.unmount()
   })
 
-  test("Заголовок блока", () => {
-    expect(wrapper.find("h2").text()).toBe(title)
+  describe("Заголовок блока", () => {
+    test("По умолчанию скрыт", () => {
+      expect(wrapper.find("h2").exists()).toBeFalsy()
+    })
+
+    test("Выставляется из props", async () => {
+      await wrapper.setProps({ title })
+
+      expect(wrapper.find("h2").text()).toBe(title)
+    })
   })
 
   test("Передача контента через slot", () => {

--- a/tests/components/ui/UiCardContent.spec.ts
+++ b/tests/components/ui/UiCardContent.spec.ts
@@ -1,0 +1,55 @@
+import type { VueWrapper } from "@vue/test-utils"
+
+import { mountSuspended } from "@nuxt/test-utils/runtime"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import UiCardContent from "~/components/ui/UiCardContent.vue"
+
+import { tags } from "./tags/UiTags.spec"
+
+describe("Компонент UiCardContent", () => {
+  const cardContent = {
+    description: "Описание",
+    tags,
+    title: "Заголовок",
+  }
+
+  let wrapper: VueWrapper
+
+  beforeEach(async () => {
+    wrapper = await mountSuspended(UiCardContent, {
+      props: cardContent,
+      shallow: true,
+    })
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
+  describe("Правильная передача полей", () => {
+    test("Заголовок", () => {
+      expect(wrapper.find("h4").text()).toBe(cardContent.title)
+    })
+
+    test("Описание", () => {
+      expect(wrapper.find("p").text()).toBe(cardContent.description)
+    })
+  })
+
+  describe("Список тегов", () => {
+    test("Передается из props", () => {
+      expect(wrapper.find("[data-test-id=tags]").attributes().tags).toBe(
+        cardContent.tags.toString()
+      )
+    })
+
+    test("Отсутствует при пустом массиве", async () => {
+      cardContent.tags = []
+
+      await wrapper.setProps(cardContent)
+
+      expect(wrapper.find("[data-test-id=tags]").exists()).toBeFalsy()
+    })
+  })
+})


### PR DESCRIPTION
- Добавление блока «Проекты» на главную и на страницу проектов
- Настройка Cloudinary для `NuxtImg`
- Компонент `UiCardContent`, перенос контента и тестов из `PersonalProjectsCard` в него
- Опциональный заголовок в `UiBlock`
- Тесты блока «Проекты», небольшие исправления в других тестах

### Связанные задачи
- Fixes EXR7-95
- Fix #382