### PR TITLE
test: Переработка использования функции `attributes()`

### DIFF
--- a/tests/components/personal-projects/PersonalProjects.spec.ts
+++ b/tests/components/personal-projects/PersonalProjects.spec.ts
@@ -79,7 +79,9 @@ describe("Компонент PersonalProjects", () => {
         limit: 3,
       })
 
-      expect(viewAllButton().attributes()).toBe("/projects#personal-projects")
+      expect(viewAllButton().attributes("to")).toBe(
+        "/projects#personal-projects"
+      )
     })
   })
 

--- a/tests/components/personal-projects/PersonalProjectsCard.spec.ts
+++ b/tests/components/personal-projects/PersonalProjectsCard.spec.ts
@@ -13,10 +13,10 @@ describe("Компонент PersonalProjectsCard", () => {
 
   let wrapper: VueWrapper
 
-  const cardContentAttributes = () =>
-    wrapper.findComponent(UiCardContent).attributes()
-  const githubLinkAttributes = () =>
-    wrapper.find("[data-test-id=github-link]").attributes()
+  const cardContentAttributes = (attribute: string) =>
+    wrapper.findComponent(UiCardContent).attributes(attribute)
+  const githubLinkAttributes = (attribute: string) =>
+    wrapper.find("[data-test-id=github-link]").attributes(attribute)
 
   beforeEach(async () => {
     wrapper = await mountSuspended(PersonalProjectsCard, {
@@ -33,11 +33,11 @@ describe("Компонент PersonalProjectsCard", () => {
 
   describe("Правильная передача полей", () => {
     test("Заголовок", () => {
-      expect(cardContentAttributes().title).toBe(personalProject.title)
+      expect(cardContentAttributes("title")).toBe(personalProject.title)
     })
 
     test("Описание", () => {
-      expect(cardContentAttributes().description).toBe(
+      expect(cardContentAttributes("description")).toBe(
         personalProject.description
       )
     })
@@ -49,17 +49,19 @@ describe("Компонент PersonalProjectsCard", () => {
     })
 
     test("Теги", () => {
-      expect(cardContentAttributes().tags).toBe(personalProject.tags.toString())
+      expect(cardContentAttributes("tags")).toBe(
+        personalProject.tags.toString()
+      )
     })
   })
 
   describe("Ссылка на GitHub", () => {
     test("Выставляется из props", () => {
-      expect(githubLinkAttributes().to).toBe(personalProject.github)
+      expect(githubLinkAttributes("to")).toBe(personalProject.github)
     })
 
     test("Открывается в новой вкладке", () => {
-      expect(githubLinkAttributes().target).toBe("_blank")
+      expect(githubLinkAttributes("target")).toBe("_blank")
     })
   })
 })

--- a/tests/components/projects/Projects.spec.ts
+++ b/tests/components/projects/Projects.spec.ts
@@ -91,7 +91,7 @@ describe("Компонент Projects", () => {
         limit: 3,
       })
 
-      expect(viewAllButton().attributes()).toBe("/projects#projects")
+      expect(viewAllButton().attributes("to")).toBe("/projects#projects")
     })
   })
 

--- a/tests/components/projects/ProjectsCard.spec.ts
+++ b/tests/components/projects/ProjectsCard.spec.ts
@@ -13,12 +13,12 @@ describe("Компонент ProjectsCard", () => {
 
   let wrapper: VueWrapper
 
-  const cardContentAttributes = () =>
-    wrapper.findComponent(UiCardContent).attributes()
-  const logoAttributes = () =>
-    wrapper.findComponent({ name: "NuxtImg" }).attributes()
-  const projectLinkAttributes = () =>
-    wrapper.find("[data-test-id=project-link]").attributes()
+  const cardContentAttributes = (attribute: string) =>
+    wrapper.findComponent(UiCardContent).attributes(attribute)
+  const logoAttributes = (attribute: string) =>
+    wrapper.findComponent({ name: "NuxtImg" }).attributes(attribute)
+  const projectLinkAttributes = (attribute: string) =>
+    wrapper.find("[data-test-id=project-link]").attributes(attribute)
 
   beforeEach(async () => {
     wrapper = await mountSuspended(ProjectsCard, {
@@ -35,15 +35,15 @@ describe("Компонент ProjectsCard", () => {
 
   describe("Правильная передача полей", () => {
     test("Заголовок", () => {
-      expect(cardContentAttributes().title).toBe(project.title)
+      expect(cardContentAttributes("title")).toBe(project.title)
     })
 
     test("Описание", () => {
-      expect(cardContentAttributes().description).toBe(project.description)
+      expect(cardContentAttributes("description")).toBe(project.description)
     })
 
     test("Теги", () => {
-      expect(cardContentAttributes().tags).toBe(project.tags.toString())
+      expect(cardContentAttributes("tags")).toBe(project.tags.toString())
     })
 
     test("Год", () => {
@@ -60,25 +60,25 @@ describe("Компонент ProjectsCard", () => {
     })
 
     test("Формат SVG", () => {
-      expect(logoAttributes().format).toBe("svg")
+      expect(logoAttributes("format")).toBe("svg")
     })
 
     test("Провайдер Cloudinary", () => {
-      expect(logoAttributes().provider).toBe("cloudinary")
+      expect(logoAttributes("provider")).toBe("cloudinary")
     })
 
     test("Значение из props", () => {
-      expect(logoAttributes().src).toBe(project.logo)
+      expect(logoAttributes("src")).toBe(project.logo)
     })
   })
 
   describe("Ссылка на проект", () => {
     test("Правильно передается из props", () => {
-      expect(projectLinkAttributes().to).toBe(project.url)
+      expect(projectLinkAttributes("to")).toBe(project.url)
     })
 
     test("Открывается в новой вкладке", () => {
-      expect(projectLinkAttributes().target).toBe("_blank")
+      expect(projectLinkAttributes("target")).toBe("_blank")
     })
   })
 })

--- a/tests/components/social/SocialCard.spec.ts
+++ b/tests/components/social/SocialCard.spec.ts
@@ -28,21 +28,21 @@ describe("Компонент SocialCard", () => {
     wrapper.unmount()
   })
 
-  const cardAttributes = () => wrapper.attributes()
+  const cardAttributes = (attribute: string) => wrapper.attributes(attribute)
 
   test("Семантический тег a", () => {
     expect(wrapper.element.tagName).toBe("A")
   })
 
   test("Открывается в новой вкладке", () => {
-    expect(cardAttributes().target).toBe("_blank")
+    expect(cardAttributes("target")).toBe("_blank")
   })
 
   test("Является внешней", () => {
-    expect(cardAttributes().rel).toBe("noopener noreferrer")
+    expect(cardAttributes("rel")).toBe("noopener noreferrer")
   })
 
   test("Ссылка из props", () => {
-    expect(cardAttributes().href).toBe(socialCard.url)
+    expect(cardAttributes("href")).toBe(socialCard.url)
   })
 })

--- a/tests/components/the-header/navigation/TheHeaderNavigationCard.spec.ts
+++ b/tests/components/the-header/navigation/TheHeaderNavigationCard.spec.ts
@@ -25,6 +25,6 @@ describe("Компонент TheHeaderNavigationCard", () => {
   })
 
   test("Ссылка на страницу — /", () => {
-    expect(wrapper.attributes().href).toBe("/")
+    expect(wrapper.attributes("href")).toBe("/")
   })
 })

--- a/tests/components/ui/UiCardContent.spec.ts
+++ b/tests/components/ui/UiCardContent.spec.ts
@@ -39,7 +39,7 @@ describe("Компонент UiCardContent", () => {
 
   describe("Список тегов", () => {
     test("Передается из props", () => {
-      expect(wrapper.find("[data-test-id=tags]").attributes().tags).toBe(
+      expect(wrapper.find("[data-test-id=tags]").attributes("tags")).toBe(
         cardContent.tags.toString()
       )
     })

--- a/tests/components/ui/UiContactMeButton.spec.ts
+++ b/tests/components/ui/UiContactMeButton.spec.ts
@@ -22,7 +22,7 @@ describe("Компонент UiContactMeButton", () => {
 
   test("Кнопка переводит на страницу «Связаться со мной»", () => {
     /** Атрибут `href` кнопки */
-    const buttonHref = wrapper.attributes().href
+    const buttonHref = wrapper.attributes("href")
 
     expect(buttonHref).toBe("/contact-me/")
   })

--- a/tests/components/ui/UiInput.spec.ts
+++ b/tests/components/ui/UiInput.spec.ts
@@ -26,15 +26,15 @@ describe("Компонент UiInput", () => {
 
   const input = () => wrapper.find("input")
   const label = () => wrapper.find("label")
-  const inputAttribute = (attribute: string) => input().attributes(attribute)
+  const inputAttributes = (attribute: string) => input().attributes(attribute)
 
   const setLabel = async () => await wrapper.setProps({ label: labelText })
 
   test("Выставление атрибутов `id` и `name` на поле ввода", () => {
     // Проверка атрибута `id`
-    expect(inputAttribute("id")).toBe(defaultProps.id)
+    expect(inputAttributes("id")).toBe(defaultProps.id)
     // Проверка атрибута `name`
-    expect(inputAttribute("name")).toBe(defaultProps.id)
+    expect(inputAttributes("name")).toBe(defaultProps.id)
   })
 
   describe("Параметр label", () => {
@@ -63,40 +63,40 @@ describe("Компонент UiInput", () => {
 
   describe("Параметр placeholder", () => {
     test("Отсутствие по умолчанию", () => {
-      expect(inputAttribute("placeholder")).toBeUndefined()
+      expect(inputAttributes("placeholder")).toBeUndefined()
     })
 
     test("Выставление при передаче параметра", async () => {
       const placeholder = "Тестовый placeholder"
       await wrapper.setProps({ placeholder })
 
-      expect(inputAttribute("placeholder")).toBe(placeholder)
+      expect(inputAttributes("placeholder")).toBe(placeholder)
     })
   })
 
   describe("Параметр required", () => {
     test("По умолчанию true", () => {
       // При преобразовании в HTML, true заменяется на пустую строку.
-      expect(inputAttribute("required")).toBe("")
+      expect(inputAttributes("required")).toBe("")
     })
 
     test("Выставление при передаче параметра", async () => {
       await wrapper.setProps({ required: false })
 
-      expect(inputAttribute("required")).toBeUndefined()
+      expect(inputAttributes("required")).toBeUndefined()
     })
   })
 
   describe("Параметр type", () => {
     test("По умолчанию text", () => {
-      expect(inputAttribute("type")).toBe("text")
+      expect(inputAttributes("type")).toBe("text")
     })
 
     test("Выставление при передаче параметра", async () => {
       const type: InputTypeHTMLAttribute = "email"
       await wrapper.setProps({ type })
 
-      expect(inputAttribute("type")).toBe(type)
+      expect(inputAttributes("type")).toBe(type)
     })
   })
 })

--- a/tests/components/ui/UiTextArea.spec.ts
+++ b/tests/components/ui/UiTextArea.spec.ts
@@ -25,16 +25,16 @@ describe("Компонент UiTextArea", () => {
 
   const textarea = () => wrapper.find("textarea")
   const label = () => wrapper.find("label")
-  const textareaAttribute = (attribute: string) =>
+  const textareaAttributes = (attribute: string) =>
     textarea().attributes(attribute)
 
   const setLabel = async () => await wrapper.setProps({ label: labelText })
 
   test("Выставление атрибутов `id` и `name` на поле ввода", () => {
     // Проверка атрибута `id`
-    expect(textareaAttribute("id")).toBe(defaultProps.id)
+    expect(textareaAttributes("id")).toBe(defaultProps.id)
     // Проверка атрибута `name`
-    expect(textareaAttribute("name")).toBe(defaultProps.id)
+    expect(textareaAttributes("name")).toBe(defaultProps.id)
   })
 
   describe("Параметр label", () => {
@@ -63,40 +63,40 @@ describe("Компонент UiTextArea", () => {
 
   describe("Параметр placeholder", () => {
     test("Отсутствие по умолчанию", () => {
-      expect(textareaAttribute("placeholder")).toBeUndefined()
+      expect(textareaAttributes("placeholder")).toBeUndefined()
     })
 
     test("Выставление при передаче параметра", async () => {
       const placeholder = "Тестовый placeholder"
       await wrapper.setProps({ placeholder })
 
-      expect(textareaAttribute("placeholder")).toBe(placeholder)
+      expect(textareaAttributes("placeholder")).toBe(placeholder)
     })
   })
 
   describe("Параметр required", () => {
     test("По умолчанию true", () => {
       // При преобразовании в HTML, true заменяется на пустую строку.
-      expect(textareaAttribute("required")).toBe("")
+      expect(textareaAttributes("required")).toBe("")
     })
 
     test("Выставление при передаче параметра", async () => {
       await wrapper.setProps({ required: false })
 
-      expect(textareaAttribute("required")).toBeUndefined()
+      expect(textareaAttributes("required")).toBeUndefined()
     })
   })
 
   describe("Параметр rows", () => {
     test("По умолчанию 4", () => {
-      expect(textareaAttribute("rows")).toBe("4")
+      expect(textareaAttributes("rows")).toBe("4")
     })
 
     test("Выставление при передаче параметра", async () => {
       const rows = 3
       await wrapper.setProps({ rows })
 
-      expect(textareaAttribute("rows")).toBe(rows.toString())
+      expect(textareaAttributes("rows")).toBe(rows.toString())
     })
   })
 })

--- a/tests/components/ui/tags/UiTags.spec.ts
+++ b/tests/components/ui/tags/UiTags.spec.ts
@@ -24,7 +24,7 @@ describe("Компонент UiTags", () => {
 
   const tagsList = () => wrapper.findAllComponents(UiTagsCard)
   const isEveryTagSmall = () =>
-    tagsList().every((tag) => tag.attributes().small === "true")
+    tagsList().every((tag) => tag.attributes("small") === "true")
 
   beforeEach(async () => {
     wrapper = await mountSuspended(UiTags, {

--- a/tests/components/ui/tags/UiTagsCard.spec.ts
+++ b/tests/components/ui/tags/UiTagsCard.spec.ts
@@ -16,7 +16,7 @@ describe("Компонент UiTagsCard", () => {
 
   let wrapper: VueWrapper
 
-  const elementClasses = () => wrapper.attributes().class
+  const elementClasses = () => wrapper.attributes("class")
 
   beforeEach(async () => {
     wrapper = await mountSuspended(UiTagsCard, {


### PR DESCRIPTION
В функцию `attributes()` можно передать параметр с названием конкретного атрибута, если необходим именно один.

### Связанная задача
Fixes EXR7-129.