### PR TITLE
feat: Настройка Robots и Sitemap

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -87,6 +87,9 @@ export default defineNuxtConfig({
       "tailwindcss/nesting": "postcss-nesting",
     },
   },
+  robots: {
+    blockNonSeoBots: true,
+  },
   routeRules: {
     "/about/": {
       prerender: true,


### PR DESCRIPTION
Настройка `robots.txt`. Настройка Sitemap не требуется, так как всё работает по умолчанию после установки Nuxt SEO.

### Связанная задача
Fixes EXR7-112.